### PR TITLE
🐛 Fix node action path in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Action
       id: action
       run: |
-        node dist/index.js
+        node ${{ github.action_path }}/dist/index.js
         echo "{z3-root}={value1}" >> $GITHUB_OUTPUT
       shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
       env:


### PR DESCRIPTION
Changed the node path in Github action from a fixed path to a dynamic path. This ensures that the action runs correctly irrespective of the current working directory and project it is run in.