### PR TITLE
🔧 introduce dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,25 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     schedule:
       interval: weekly
       day: "monday"
       time: "06:00"
       timezone: "Europe/Vienna"
-    assignees:
-      - "burgholzer"
 
   - package-ecosystem: npm
     directory: /
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
     schedule:
       interval: weekly
       day: "monday"
       time: "06:00"
       timezone: "Europe/Vienna"
-    assignees:
-      - "burgholzer"


### PR DESCRIPTION
Introduced groups in the dependabot.yml file for better organization and management of dependencies. Dependabot groups allow to open single PRs for multiple dependencies; thus reducing the maintenance overhead. Additionally, the property 'assignees' was removed for broader responsibility.