### PR TITLE
⬆️ Switching to node 20

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 18
+      - name: Set Node.js
         uses: actions/setup-node@v3.7.0
         with:
-          node-version: 18
+          node-version: 20.x
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set Node.js 18
+      - name: Set Node.js
         uses: actions/setup-node@v3.7.0
         with:
-          node-version: 18
+          node-version: 20.x
           cache: npm
       - run: npm ci
       - run: npm run all

--- a/action.yml
+++ b/action.yml
@@ -17,24 +17,9 @@ inputs:
 outputs:
   z3-root:
     description: "The root directory of the Z3 installation"
-    value: ${{ steps.action.outputs.z3-root }}
 runs:
-  using: composite
-  steps:
-    - name: Setup Node
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - name: Action
-      id: action
-      run: |
-        node ${{ github.action_path }}/dist/index.js
-        echo "{z3-root}={value1}" >> $GITHUB_OUTPUT
-      shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
-      env:
-        INPUT_VERSION: ${{ inputs.version }}
-        INPUT_PLATFORM: ${{ inputs.platform }}
-        INPUT_ARCHITECTURE: ${{ inputs.architecture }}
+  using: "node20"
+  main: "dist/index.js"
 branding:
   icon: "package"
   color: "blue"


### PR DESCRIPTION
This PR switches the action to Node.js 20, which is now widely available on GitHub runners.
This simplifies the overall action code and brings the action in line with what GitHub recommends for actions in the future.